### PR TITLE
mult and add errors fixed

### DIFF
--- a/strint.js
+++ b/strint.js
@@ -63,7 +63,7 @@ define(function () {
             }
         }
         if (borrow > 0) {
-            result = String(borrow) + result;
+            result = String(borrow * Math.pow(10, leadingZeros)) + result;
         }
         return result;
     }
@@ -108,13 +108,10 @@ define(function () {
         var digitCount = getDigitCount(strint);
         var carry = 0;
         var leadingZeros = 0;
-        for(var i=0; i<digitCount; i++) {
+        for(var i=0; i<=digitCount; i++) {
             var digitResult = (Number(getDigit(strint, i)) * digit) + carry;
-            carry = 0;
-            while(digitResult >= 10) {
-                digitResult -= 10;
-                carry++;
-            }
+            carry = parseInt(digitResult/10,10);
+            digitResult = digitResult % 10;
             if (digitResult === 0) {
                 leadingZeros++;
             } else {


### PR DESCRIPTION
Now, we can use the the is a built-in object `BigInt`. See [BigInt - JavaScript | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)

---------

Fixed add errors. Based on commit `89ec217195fb09aa3a63010284923d98a8ef4401`.

When using `strint("403291461126605635584000000", "27")` to calculate `27!`. 

false：
```
   2 823040227886239449088000000
 + 8 065829222532112711680000000
------------------------------------
   1 888869450418352160768000000
```
true：
```
   2 823040227886239449088000000
 + 8 065829222532112711680000000
------------------------------------
  10 888869450418352160768000000
```